### PR TITLE
Updating package so that it uses scipy.stats.contingency.association

### DIFF
--- a/association_metrics/categorical.py
+++ b/association_metrics/categorical.py
@@ -4,17 +4,19 @@ Created on Wed Feb  3 06:36:23 2021
 
 @author: HTRUJILLO
 """
-from scipy.stats import chi2_contingency
-from pandas import DataFrame,crosstab
-from numpy import sqrt, zeros
+from scipy.stats.contingency import association
+from pandas import DataFrame, crosstab
+from numpy import sqrt, zeros, eye
 from .pairwise import PairWisemetrics
+from itertools import combinations
+
 
 class CramersV(PairWisemetrics):
     
     def __init__(self, dataframe):
         PairWisemetrics.__init__(self, dataframe)
         self.matrix = None
-        
+
     def select_variables(self):
         '''
         Selects all category variables
@@ -26,62 +28,33 @@ class CramersV(PairWisemetrics):
         '''
         self.cat_columns = self.data.select_dtypes(
             include=['category']).columns
-        
+
         if len(self.cat_columns)==0:
             raise KeyError("No categorical variables found")
-    
+
     def init_pairwisematrix(self):
         '''
-        init a square matrix n x n fill with zeros, where n is the total number of categorical variables found in the pandas.DataFrame
+        init a square matrix n x n fill with zeros,
+        where n is the total number of categorical variables
+        found in the pd.DataFrame
 
         Returns
         -------
         None.
 
         '''
+        # fill matrix with zeros, except for the main diag (which will
+        # be always equal to one)
         self.matrix = DataFrame(
-            data = zeros(
-                (len(self.cat_columns),len(self.cat_columns))),
-        columns = self.cat_columns,
-        index = self.cat_columns)
-        
-     
-    def measure_association(self, x, y):
-        '''
-        Calculates Cramer's V based on Pearson's chi-squared statistic
-        
-        Parameters
-        ----------
-        x : pandas.Series containing one categorical variable
-        
-        y : pandas.Series containing one categorical variable
-        
-        Returns
-        -------
-        v: float 
-        cramers value
+            eye(len(self.cat_columns)),
+            columns=self.cat_columns,
+            index=self.cat_columns
+        )
 
-        '''
-        if x.nunique()== 1 or y.nunique()== 1:
-            x_name = x.name
-            y_name = y.name
-            msg = "{} and {} ".format(x_name, y_name)
-            msg += "must have at least 2 different levels"
-            raise ValueError(msg)
-        
-        contingency_table = crosstab(x,y)
-        chi2 = chi2_contingency(contingency_table, correction = False)[0]
-        
-        n = contingency_table.sum().sum()
-        mindim = min(contingency_table.shape)-1
-        
-        v = sqrt((chi2/n)/mindim)
-    
-        return v
-        
+
     def fill_pairwisematrix(self):
         '''
-        fills the square matrix using measure_association method
+        fills the square matrix using scipy's association method
 
         Returns
         -------
@@ -90,23 +63,33 @@ class CramersV(PairWisemetrics):
         '''
         
         n = len(self.cat_columns)
-        
-        for i in range(0,n):
-            x = self.cat_columns[i]
-            for j in range(i,n):
-                y = self.cat_columns[j]
-                
-                if x == y:
-                    self.matrix[x][y] = 1
-                else:
-                    value = self.measure_association(
-                        self.data[x], self.data[y])
-                    self.matrix[x][y] = value
-                    self.matrix[y][x] = value
-    
+        # get all possible pair-wise combinations in the columns list
+        # this assumes that A-->B equals B-->A so we don't need to
+        # calculate the same thing twice
+        # we also never get "A --> A"
+        all_combinations = combinations(self.cat_columns, r=2)
+
+        # note that because we ignore redundant combinations,
+        # we perform half the calculations, so we get the results
+        # twice as fast
+        for comb in all_combinations:
+            i = comb[0]
+            j = comb[1]
+
+            # make contingency table
+            input_tab = crosstab(self.data[i], self.data[j])
+
+            # find the resulting cramer association value using scipy's
+            # association method
+            res_cramer = association(input_tab, method='cramer')
+            self.matrix[i][j], self.matrix[j][i] = res_cramer, res_cramer
+
+
     def fit(self):
         '''
-        Creates a pairwise matrix filled with Cramer's V, where columns and index are the categorical variables of the passed pandas.DataFrame
+        Creates a pairwise matrix filled with Cramer's V,
+        where columns and index are the categorical
+        variables of the passed pandas.DataFrame
 
         Returns
         -------
@@ -116,5 +99,5 @@ class CramersV(PairWisemetrics):
         self.select_variables()
         self.init_pairwisematrix()
         self.fill_pairwisematrix()
-        
+
         return self.matrix

--- a/association_metrics/pairwise.py
+++ b/association_metrics/pairwise.py
@@ -15,7 +15,8 @@ class PairWisemetrics:
         Parameters
         ----------
         dataframe : pandas.DataFrame
-            Pandas dataframe containing the variables of interest to measure the degree of association.
+            Pandas dataframe containing the variables
+            of interest to measure the degree of association.
 
         Returns
         -------
@@ -30,7 +31,4 @@ class PairWisemetrics:
                 self.data = dataframe
                 
         else:
-            raise TypeError("dataframe must be an instance of a pandas.DataFrame")
-
-    def measure_association(self):
-        pass
+            raise TypeError("dataframe must be an instance of a pd.DataFrame")

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="association-metrics", # Replace with your own username
-    version="0.0.1",
+    version="0.0.2",
     author="Heber Trujillo",
     author_email="heber.trj.urt@gmail.com",
     description="Python module for measure the degree of association between variables",

--- a/tests.py
+++ b/tests.py
@@ -48,26 +48,6 @@ class TestMetrics(unittest.TestCase):
         matrix_shape = cramersv.matrix.shape
         self.assertEqual(matrix_shape, (4,4))
         
-    def test_cramers_measure_association(self):
-        tips = read_csv(
-            "./association_metrics/datasets/tips.csv")
-        tips = tips.apply(
-            lambda x: x.astype("category") if x.dtype == "O" else x)
-    
-        cramersv = am.CramersV(tips)
-        
-        sex = tips['sex']
-        smoker = tips['smoker']
-        
-        day = tips['day']
-        time = tips['time']
-        
-        value_1 = cramersv.measure_association(sex,smoker)
-        value_1 = round(value_1,6)
-        value_2 = cramersv.measure_association(time,day)
-        value_2 = round(value_2,6)
-        self.assertEqual((value_1,value_2), (0.002816,0.943295))
-        
     def test_cramers_fit(self):
         tips = read_csv(
             "./association_metrics/datasets/tips.csv")


### PR DESCRIPTION
# Update Overview
* I deleted the measure_association function, as it was unnecessary.[ Scipy's association function](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.contingency.association.html#:~:text=association,-scipy.stats.contingency&text=Calculates%20degree%20of%20association%20between,Contingency%20Coefficient%20and%20Cramer's%20V.) does the exact same thing. 
* The correlation matrix, so to speak, is symmetrical. Because of that, we don't need to calculate NxN operations, but (N*N)/2, where N is the number of features wanted. To solve that, I used `itertools.combinations`. It finds all possible combinations without repetition in a set.
* I also updated some documentation as to reflect changes.


Let me know if there's anything more I could include here.