### PR TITLE
Update categorical.py

### DIFF
--- a/association_metrics/categorical.py
+++ b/association_metrics/categorical.py
@@ -82,7 +82,7 @@ class CramersV(PairWisemetrics):
             # find the resulting cramer association value using scipy's
             # association method
             res_cramer = association(input_tab, method='cramer')
-            self.matrix[i][j], self.matrix[j][i] = res_cramer, res_cramer
+            self.matrix.loc[i, j], self.matrix.loc[j, i] = res_cramer, res_cramer
 
 
     def fit(self):


### PR DESCRIPTION
Pandas 3.0 introduces a significant change in behavior with the default enabling of Copy-on-Write (CoW). This change aims to improve performance and simplify the indexing API by ensuring that DataFrames and Series derived from others always behave as copies. Current version of assotiation_metrics gets warning of ChainedAssignmentError or a FutureWarning related to chained assignment, which will become an error by default in Pandas 3.0 when CoW is enabled.  This warning indicates that you are attempting to modify a DataFrame or Series through a series of operations (chained assignment) where an intermediate object is created, and the modification of this intermediate object will not propagate back to the original DataFrame or Series when CoW is active. To avoid this issue and ensure your code functions correctly with CoW, you should perform assignments in a single step using .loc or .iloc for explicit indexing By adapting your code to use .loc or .iloc for assignments, you ensure that modifications directly target the intended location in the original DataFrame or Series, preventing the creation of temporary objects that would behave as copies under CoW